### PR TITLE
Add Scripts to launch API from root 

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "Application stack driving mainwaring.dev",
   "main": "package.json",
   "scripts": {
+    "build:api": "cd packages/api && npx strapi build",
+    "start:api": "cd packages/api && npx strapi start",
     "test": "npx jest",
     "test:coverage": "npx jest --coverage"
   },


### PR DESCRIPTION
This pull request adds `npm run build:api` and `npm run start:api` scripts to the root manifest.  